### PR TITLE
CPI-53: Extending transformation tool for anonymisation activity

### DIFF
--- a/event-tool/src/test/java/uk/gov/justice/event/tool/StartTransformationTest.java
+++ b/event-tool/src/test/java/uk/gov/justice/event/tool/StartTransformationTest.java
@@ -258,6 +258,9 @@ public class StartTransformationTest {
 
         startTransformation.go();
 
+        verify(logger).info("-------------- Invoke Event Streams Transformation -------------");
+        verify(logger).info("-------------- Invocation of Event Streams Transformation Completed --------------");
+        verify(logger).info("Processing active streams");
         verify(logger).info("Pass 1 - Streams count: 4 - time(ms): 12222222");
         startTransformation.taskDone(future1, null, null, null);
         startTransformation.taskDone(future2, null, null, null);

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <cpp.repo.name>stream-transformation-tool</cpp.repo.name>
         <framework-api.version>3.1.1</framework-api.version>
         <framework.version>5.1.2</framework.version>
-        <event-store.version>1.1.9</event-store.version>
+        <event-store.version>1.1.11</event-store.version>
         <common-bom.version>1.28.0</common-bom.version>
         <utilities.version>1.16.2</utilities.version>
         <test-utils.version>1.18.1</test-utils.version>
@@ -103,11 +103,12 @@
             <dependency>
                 <groupId>uk.gov.justice.services</groupId>
                 <artifactId>event-repository-liquibase</artifactId>
-                <version>${framework.version}</version>
+                <version>${event-store.version}</version>
             </dependency>
             <dependency>
                 <groupId>uk.gov.justice.event-store</groupId>
                 <artifactId>event-repository-jdbc</artifactId>
+                <version>${event-store.version}</version>
             </dependency>
             <dependency>
                 <groupId>uk.gov.justice.utils</groupId>

--- a/stream-transformation-test/stream-transformation-it/src/main/java/uk/gov/justice/framework/tools/transformation/EventLogBuilder.java
+++ b/stream-transformation-test/stream-transformation-it/src/main/java/uk/gov/justice/framework/tools/transformation/EventLogBuilder.java
@@ -1,5 +1,6 @@
 package uk.gov.justice.framework.tools.transformation;
 
+import static java.util.Optional.empty;
 import static java.util.Optional.of;
 import static uk.gov.justice.services.test.utils.core.messaging.JsonEnvelopeBuilder.envelope;
 import static uk.gov.justice.services.test.utils.core.messaging.MetadataBuilderFactory.metadataWithRandomUUID;
@@ -9,42 +10,23 @@ import uk.gov.justice.services.messaging.JsonEnvelope;
 import uk.gov.justice.services.messaging.Metadata;
 
 import java.time.ZonedDateTime;
+import java.util.Optional;
 import java.util.UUID;
 
 public class EventLogBuilder {
 
     private EventLogBuilder() {
-
+        // should not create an instance of this class
     }
+
     public static Event eventLogFrom(
             final String eventName,
             final Long sequenceId,
             final UUID streamId,
             final ZonedDateTime createdAt) {
-        final JsonEnvelope jsonEnvelope = envelope()
-                .with(metadataWithRandomUUID(eventName)
-                        .createdAt(createdAt)
-                        .withVersion(sequenceId)
-                        .withStreamId(streamId)
-                        .withSource("sample")
-                )
-                .withPayloadOf("test", "a string")
-                .build();
 
-        final Metadata metadata = jsonEnvelope.metadata();
-        final UUID id = metadata.id();
+        return eventLogFrom(eventName, sequenceId, streamId, createdAt, empty());
 
-        final String name = metadata.name();
-        final String payload = jsonEnvelope.payloadAsJsonObject().toString();
-
-        return new Event(
-                id,
-                streamId,
-                sequenceId,
-                name,
-                metadata.asJsonObject().toString(),
-                payload,
-                createdAt);
     }
 
     public static Event eventLogFrom(
@@ -53,6 +35,17 @@ public class EventLogBuilder {
             final UUID streamId,
             final ZonedDateTime createdAt,
             final long eventNumber) {
+
+        return eventLogFrom(eventName, sequenceId, streamId, createdAt, of(eventNumber));
+    }
+
+    public static Event eventLogFrom(
+            final String eventName,
+            final Long sequenceId,
+            final UUID streamId,
+            final ZonedDateTime createdAt,
+            final Optional<Long> eventNumber) {
+
         final JsonEnvelope jsonEnvelope = envelope()
                 .with(metadataWithRandomUUID(eventName)
                         .createdAt(createdAt)
@@ -77,6 +70,6 @@ public class EventLogBuilder {
                 metadata.asJsonObject().toString(),
                 payload,
                 createdAt,
-                of(eventNumber));
+                eventNumber);
     }
 }


### PR DESCRIPTION
This is to allow processing inactive streams (required only for anonymisation activity and is not recommended for any other usage scenarios)