### PR TITLE
Adding ability to whitelist attributes at a global level

### DIFF
--- a/stream-transformation-tool-anonymise/src/main/java/uk/gov/justice/tools/eventsourcing/anonymization/model/Events.java
+++ b/stream-transformation-tool-anonymise/src/main/java/uk/gov/justice/tools/eventsourcing/anonymization/model/Events.java
@@ -5,13 +5,15 @@ import java.util.List;
 
 public class Events {
 
+    private List<String> globalAttributes;
+
     private List<Event> events;
 
     public Events() {
     }
 
-    public Events(final List<Event> events) {
-        this.events = events;
+    public List<String> getGlobalAttributes() {
+        return globalAttributes;
     }
 
     public List<Event> getEvents() {

--- a/stream-transformation-tool-anonymise/src/main/resources/schema/event-anonymisation-schema.json
+++ b/stream-transformation-tool-anonymise/src/main/resources/schema/event-anonymisation-schema.json
@@ -2,6 +2,15 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "properties": {
+    "globalAttributes": {
+      "type": "array",
+      "description": "Fields that are considered for all events.  This field does not denote a complete JSON path.  It only identifies the ending of a json path (partial entry)",
+      "items": [
+        {
+          "type": "string"
+        }
+      ]
+    },
     "events": {
       "type": "array",
       "items": [
@@ -23,12 +32,14 @@
           "required": [
             "eventName",
             "fieldsToBeIgnored"
-          ]
+          ],
+          "additionalProperties": false
         }
       ]
     }
   },
   "required": [
     "events"
-  ]
+  ],
+  "additionalProperties": false
 }

--- a/stream-transformation-tool-anonymise/src/test/java/uk/gov/justice/tools/eventsourcing/anonymization/service/EventAnonymiserServiceTest.java
+++ b/stream-transformation-tool-anonymise/src/test/java/uk/gov/justice/tools/eventsourcing/anonymization/service/EventAnonymiserServiceTest.java
@@ -100,6 +100,23 @@ public class EventAnonymiserServiceTest {
         assertThat(anonymisedJsonArray.getString(6), is("SC208979B"));
     }
 
+    @Test
+    public void shouldNotAnonymiseGloballyWhitelistedAttributes() {
+        final JsonObject anonymisedPayload = service.anonymiseObjectPayload(buildObjectPayload("test-object-data.json"), "test-object-event");
+        final JsonArray exampleArray = anonymisedPayload.getJsonArray("exampleArray");
+        assertThat(exampleArray.getJsonObject(0).getJsonArray("repeatingParentArrayAttribute").getJsonObject(0).getString("repeatingChildAttribute"), is("child1"));
+        assertThat(exampleArray.getJsonObject(0).getJsonArray("repeatingParentArrayAttribute").getJsonObject(0).getString("repeatingAttribute"), is("test1"));
+        assertThat(exampleArray.getJsonObject(0).getJsonArray("repeatingParentArrayAttribute").getJsonObject(0).getJsonArray("repeatingParentArrayAttribute").getJsonObject(0).getString("repeatingChildAttribute"), is("child2"));
+        assertThat(exampleArray.getJsonObject(0).getJsonArray("repeatingParentArrayAttribute").getJsonObject(0).getJsonArray("repeatingParentArrayAttribute").getJsonObject(0).getString("repeatingAttribute"), is("test2"));
+
+        final JsonObject exampleObject = anonymisedPayload.getJsonObject("example");
+        final JsonObject repeatingObject = exampleObject.getJsonObject("repeatingParentObjectAttribute");
+        assertThat(repeatingObject.getString("repeatingChildAttribute"), is("child3"));
+        assertThat(repeatingObject.getString("repeatingAttribute"), is("test3"));
+        assertThat(repeatingObject.getJsonObject("repeatingParentObjectAttribute").getString("repeatingChildAttribute"), is("child4"));
+        assertThat(repeatingObject.getJsonObject("repeatingParentObjectAttribute").getString("repeatingAttribute"), is("test4"));
+    }
+
 
     private JsonObject buildObjectPayload(final String payloadFileName) {
         final JsonReader jsonReader = createReader(new StringReader(getFileContentsAsString(payloadFileName)));

--- a/stream-transformation-tool-anonymise/src/test/resources/events-anonymisation-rule.json
+++ b/stream-transformation-tool-anonymise/src/test/resources/events-anonymisation-rule.json
@@ -1,4 +1,9 @@
 {
+  "globalAttributes": [
+    "repeatingParentArrayAttribute[*].repeatingChildAttribute",
+    "repeatingParentObjectAttribute.repeatingChildAttribute",
+    "repeatingAttribute"
+  ],
   "events": [
     {
       "eventName": "test-object-event",

--- a/stream-transformation-tool-anonymise/src/test/resources/test-object-data.json
+++ b/stream-transformation-tool-anonymise/src/test/resources/test-object-data.json
@@ -2,7 +2,19 @@
   "exampleArray": [
     {
       "attributeIntAsString": "001",
-      "attributeIntAsStringAnonymise": "001"
+      "attributeIntAsStringAnonymise": "001",
+      "repeatingParentArrayAttribute": [
+        {
+          "repeatingChildAttribute": "child1",
+          "repeatingAttribute" : "test1",
+          "repeatingParentArrayAttribute": [
+            {
+              "repeatingChildAttribute": "child2",
+              "repeatingAttribute" : "test2"
+            }
+          ]
+        }
+      ]
     }
   ],
   "example": {
@@ -27,6 +39,14 @@
       },
       "test234@mail.com",
       "SC208979B"
-    ]
+    ],
+    "repeatingParentObjectAttribute": {
+      "repeatingChildAttribute": "child3",
+      "repeatingAttribute" : "test3",
+      "repeatingParentObjectAttribute": {
+        "repeatingChildAttribute": "child4",
+        "repeatingAttribute" : "test4"
+      }
+    }
   }
 }


### PR DESCRIPTION
The global attributes are not fully qualified json path and rely on the json path for an attribute (not object or array) ending with it