### PR TITLE
Backporting changes from framework 6 version of the tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ on [Keep a CHANGELOG](http://keepachangelog.com/). This project adheres to
 [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
-
+- Gson library available for easier manipulation of json objects for transformation
 
 ## [5.3.5] - 2020-02-25
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ on [Keep a CHANGELOG](http://keepachangelog.com/). This project adheres to
 
 ## [Unreleased]
 - Gson library available for easier manipulation of json objects for transformation
+- Surfacing all exception when processing a stream
+- Json path library added
+- Added global whitelisting of attributes when using the anonymisation cartridge.  This will now make it easier to 
+ignore attributes which occur in a repeating or nested manner.  This approach is limited to just data types other 
+than an object or array.  The global attributes are not fully qualified path and just denote the ending of the path
+
 
 ## [5.3.5] - 2020-02-25
 ### Added

--- a/event-tool/pom.xml
+++ b/event-tool/pom.xml
@@ -93,6 +93,12 @@
             <artifactId>logging</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>${gson.version}</version>
+        </dependency>
+
         <!--External-->
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/event-tool/pom.xml
+++ b/event-tool/pom.xml
@@ -98,6 +98,10 @@
             <artifactId>gson</artifactId>
             <version>${gson.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.jayway.jsonpath</groupId>
+            <artifactId>json-path</artifactId>
+        </dependency>
 
         <!--External-->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,8 @@
         <wildfly.swarm.version>2017.11.0</wildfly.swarm.version>
         <version.swarm.fraction-plugin>77</version.swarm.fraction-plugin>
         <junit-dataprovider.version>1.13.1</junit-dataprovider.version>
-
+        <!-- Locking version of gson library as the next version 2.8.6 is bring up error on swarm starting up-->
+        <gson.version>2.8.5</gson.version>
     </properties>
 
     <modules>

--- a/stream-transformation-tool-anonymise/src/main/java/uk/gov/justice/tools/eventsourcing/anonymization/model/Events.java
+++ b/stream-transformation-tool-anonymise/src/main/java/uk/gov/justice/tools/eventsourcing/anonymization/model/Events.java
@@ -5,13 +5,15 @@ import java.util.List;
 
 public class Events {
 
+    private List<String> globalAttributes;
+
     private List<Event> events;
 
     public Events() {
     }
 
-    public Events(final List<Event> events) {
-        this.events = events;
+    public List<String> getGlobalAttributes() {
+        return globalAttributes;
     }
 
     public List<Event> getEvents() {

--- a/stream-transformation-tool-anonymise/src/main/resources/schema/event-anonymisation-schema.json
+++ b/stream-transformation-tool-anonymise/src/main/resources/schema/event-anonymisation-schema.json
@@ -2,6 +2,15 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "properties": {
+    "globalAttributes": {
+      "type": "array",
+      "description": "Fields that are considered for all events.  This field does not denote a complete JSON path.  It only identifies the ending of a json path (partial entry)",
+      "items": [
+        {
+          "type": "string"
+        }
+      ]
+    },
     "events": {
       "type": "array",
       "items": [
@@ -23,12 +32,14 @@
           "required": [
             "eventName",
             "fieldsToBeIgnored"
-          ]
+          ],
+          "additionalProperties": false
         }
       ]
     }
   },
   "required": [
     "events"
-  ]
+  ],
+  "additionalProperties": false
 }

--- a/stream-transformation-tool-anonymise/src/test/java/uk/gov/justice/tools/eventsourcing/anonymization/service/EventAnonymiserServiceTest.java
+++ b/stream-transformation-tool-anonymise/src/test/java/uk/gov/justice/tools/eventsourcing/anonymization/service/EventAnonymiserServiceTest.java
@@ -100,6 +100,23 @@ public class EventAnonymiserServiceTest {
         assertThat(anonymisedJsonArray.getString(6), is("SC208979B"));
     }
 
+    @Test
+    public void shouldNotAnonymiseGloballyWhitelistedAttributes() {
+        final JsonObject anonymisedPayload = service.anonymiseObjectPayload(buildObjectPayload("test-object-data.json"), "test-object-event");
+        final JsonArray exampleArray = anonymisedPayload.getJsonArray("exampleArray");
+        assertThat(exampleArray.getJsonObject(0).getJsonArray("repeatingParentArrayAttribute").getJsonObject(0).getString("repeatingChildAttribute"), is("child1"));
+        assertThat(exampleArray.getJsonObject(0).getJsonArray("repeatingParentArrayAttribute").getJsonObject(0).getString("repeatingAttribute"), is("test1"));
+        assertThat(exampleArray.getJsonObject(0).getJsonArray("repeatingParentArrayAttribute").getJsonObject(0).getJsonArray("repeatingParentArrayAttribute").getJsonObject(0).getString("repeatingChildAttribute"), is("child2"));
+        assertThat(exampleArray.getJsonObject(0).getJsonArray("repeatingParentArrayAttribute").getJsonObject(0).getJsonArray("repeatingParentArrayAttribute").getJsonObject(0).getString("repeatingAttribute"), is("test2"));
+
+        final JsonObject exampleObject = anonymisedPayload.getJsonObject("example");
+        final JsonObject repeatingObject = exampleObject.getJsonObject("repeatingParentObjectAttribute");
+        assertThat(repeatingObject.getString("repeatingChildAttribute"), is("child3"));
+        assertThat(repeatingObject.getString("repeatingAttribute"), is("test3"));
+        assertThat(repeatingObject.getJsonObject("repeatingParentObjectAttribute").getString("repeatingChildAttribute"), is("child4"));
+        assertThat(repeatingObject.getJsonObject("repeatingParentObjectAttribute").getString("repeatingAttribute"), is("test4"));
+    }
+
 
     private JsonObject buildObjectPayload(final String payloadFileName) {
         final JsonReader jsonReader = createReader(new StringReader(getFileContentsAsString(payloadFileName)));

--- a/stream-transformation-tool-anonymise/src/test/resources/events-anonymisation-rule.json
+++ b/stream-transformation-tool-anonymise/src/test/resources/events-anonymisation-rule.json
@@ -1,4 +1,9 @@
 {
+  "globalAttributes": [
+    "repeatingParentArrayAttribute[*].repeatingChildAttribute",
+    "repeatingParentObjectAttribute.repeatingChildAttribute",
+    "repeatingAttribute"
+  ],
   "events": [
     {
       "eventName": "test-object-event",

--- a/stream-transformation-tool-anonymise/src/test/resources/test-object-data.json
+++ b/stream-transformation-tool-anonymise/src/test/resources/test-object-data.json
@@ -2,7 +2,19 @@
   "exampleArray": [
     {
       "attributeIntAsString": "001",
-      "attributeIntAsStringAnonymise": "001"
+      "attributeIntAsStringAnonymise": "001",
+      "repeatingParentArrayAttribute": [
+        {
+          "repeatingChildAttribute": "child1",
+          "repeatingAttribute" : "test1",
+          "repeatingParentArrayAttribute": [
+            {
+              "repeatingChildAttribute": "child2",
+              "repeatingAttribute" : "test2"
+            }
+          ]
+        }
+      ]
     }
   ],
   "example": {
@@ -27,6 +39,14 @@
       },
       "test234@mail.com",
       "SC208979B"
-    ]
+    ],
+    "repeatingParentObjectAttribute": {
+      "repeatingChildAttribute": "child3",
+      "repeatingAttribute" : "test3",
+      "repeatingParentObjectAttribute": {
+        "repeatingChildAttribute": "child4",
+        "repeatingAttribute" : "test4"
+      }
+    }
   }
 }

--- a/stream-transformation-tool-api/pom.xml
+++ b/stream-transformation-tool-api/pom.xml
@@ -22,6 +22,11 @@
             <groupId>uk.gov.justice.services</groupId>
             <artifactId>messaging-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>${gson.version}</version>
+        </dependency>
     </dependencies>
 
 </project>


### PR DESCRIPTION
- Gson library available for easier manipulation of json objects for transformation
- Surfacing all exception when processing a stream
- Json path library added
- Added global whitelisting of attributes when using the anonymisation cartridge.  This will now make it easier to ignore attributes which occur in a repeating or nested manner.  This approach is limited to just data types other than an object or array.  The global attributes are not fully qualified path and just denote the ending of the path